### PR TITLE
Installation: remove wl12xx-tool.sh from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,6 @@ install:
 	@echo Copy files to $(NFSROOT)/home/root
 	@cp -f ./calibrator $(NFSROOT)/home/root
 	@chmod 755 $(NFSROOT)/home/root/calibrator
-	@cp -f ./scripts/wl12xx-tool.sh $(NFSROOT)/home/root
-	@chmod 755 $(NFSROOT)/home/root/wl12xx-tool.sh
 
 clean:
 	@rm -f *.o calibrator uim


### PR DESCRIPTION
This script no longer exists, hence remove it from
the installation target.

Signed-off-by: Yegor Yefremov yegorslists@googlemail.com
